### PR TITLE
Don't store FurAffinity password after logging in

### DIFF
--- a/FurLoader/Sites/FurAffinity.cs
+++ b/FurLoader/Sites/FurAffinity.cs
@@ -106,7 +106,7 @@ namespace Furloader.Sites
             {
                 Uri uri = new Uri(FABase);
                 string cookie = webHandler.getCookies(uri);
-                datahandler.setLogin("furaffinity", cookie, username, password);
+                datahandler.setLogin("furaffinity", cookie, username, "");
                 return true;
             }
             return false;


### PR DESCRIPTION
Since you've got a cookie for FurAffinity, there's no reason to store the password.

You could also remove the need to store the Inkbunny password by storing the "sid" instead, but that's beyond the scope of this pull request, and I have my own library for Inkbunny anyway.